### PR TITLE
feat(src/pages/main): 캘린더 월 단위 날짜 전환 구현

### DIFF
--- a/src/pages/main/components/MainCalender.js
+++ b/src/pages/main/components/MainCalender.js
@@ -3,12 +3,21 @@
 import CalenderUtils from "../utils/CalenderUtils";
 
 import "../styles/MainCalender.css";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 const MainCalender = () => {
-  const [dateState, setDateState] = useState({
-    monthList: CalenderUtils.monthList()
-  });
+  const [dateState, setDateState] = useState({});
+
+  const [clickBtn, setClickBtn] = useState(false);
+  const [directionBtn, setDirectionBtn]  = useState('');
+
+  useEffect(() => {
+    if(directionBtn === '') setDateState({ monthList: CalenderUtils.monthList() });
+    else if(clickBtn) {
+      setDateState({ monthList: CalenderUtils.updateCalender(directionBtn) });
+      setClickBtn(false);
+    }
+  },[directionBtn, clickBtn]);
 
   const calenderHeader = () => {
     const dayWeek = [['일', '1'], ['월', '0.9'], ['화', '0.8'], ['수', '0.7'], ['목', '0.6'], ['금', '0.5'], ['토', '0.4']];
@@ -38,15 +47,22 @@ const MainCalender = () => {
   const calenderBody = () => {
     const body = [];
 
-    for(let i = 0; i < dateState.monthList.length; i++) {
-      body.push(
-        <div key={i} id="calender_body_element" style={colorCheck(dateState.monthList[i])}>
-          {dateState.monthList[i]}
-        </div>
-      );
+    if(dateState.monthList) {
+      for(let i = 0; i < dateState.monthList.length; i++) {
+        body.push(
+          <div key={i} id="calender_body_element" style={colorCheck(dateState.monthList[i])}>
+            {dateState.monthList[i]}
+          </div>
+        );
+      }
     }
 
     return body;
+  }
+
+  const turnOverCalender = (direction) => {
+    setClickBtn(true);
+    setDirectionBtn(direction);
   }
 
   return (
@@ -56,8 +72,8 @@ const MainCalender = () => {
         <div id="calender_header">{calenderHeader()}</div>
         <div id="calender_body">
           {calenderBody()}
-          <div className="calender_left_button"><img src="images/calender_left_button.png" alt="left"/></div>
-          <div className="calender_right_button"><img src="images/calender_right_button.png" alt="right"/></div>
+          <div className="calender_left_button"><img src="images/calender_left_button.png" alt="left" onClick={() => turnOverCalender('left')}/></div>
+          <div className="calender_right_button"><img src="images/calender_right_button.png" alt="right" onClick={() => turnOverCalender('right')}/></div>
         </div>
       </div>
     </div>

--- a/src/pages/main/utils/CalenderUtils.js
+++ b/src/pages/main/utils/CalenderUtils.js
@@ -12,18 +12,21 @@ const CalenderUtils = {
         endDay: ''
     },
 
+    // 달력 날짜 리스트 생성 및 반환
     monthList() {
         const thisSunday = this.checkSunday();
         const startDay = new Date(thisSunday.getFullYear(), thisSunday.getMonth(), thisSunday.getDate() - 6);
         const endDay = new Date(thisSunday.getFullYear(), thisSunday.getMonth(), thisSunday.getDate() + 28);
+    
         this.initMonthStandard(startDay, endDay);
 
-        let monthList = this.getDatesMonth(startDay, endDay);
+        let monthList = this.getDatesMonth();
         monthList = this.filterMonth(monthList);
 
         return monthList;
     },
 
+    // 금일 기준 전 일요일 반환
     checkSunday() {
         const todayChar = this.makeChar(new Date());
         const thisWeekumber = new Date(todayChar).getDay();
@@ -35,21 +38,29 @@ const CalenderUtils = {
         return thisSunday;
     },
 
+    // 날씨 데이터 중 필요한 부분만 수정하여 반환
     makeChar(date) {
         return date.toISOString().split('T')[0];
     },
 
-    getDatesMonth(startDate, endDate) {
+    // 리스트 생성 및 반환
+    getDatesMonth() {
         const result = [];
 
-        while(startDate <= endDate) {
-          result.push(startDate.toISOString().split("T")[0]);
-          startDate.setDate(startDate.getDate() + 1);
+        let temp_startDay = this.monthStandard.startDay;
+        let temp_endDay = this.monthStandard.endDay;
+
+        while(temp_startDay <= temp_endDay) {
+            result.push(temp_startDay.toISOString().split("T")[0]);
+            temp_startDay.setDate(temp_startDay.getDate() + 1);
         }
+
+        temp_startDay.setDate(temp_startDay.getDate() - 35);
 
         return result;
     },
 
+    // 날짜 초기 설정
     initToday(today) {
         this.today = {
             year: today.getFullYear(), 
@@ -58,6 +69,7 @@ const CalenderUtils = {
         };
     },
 
+    // 달력 첫번 째 날짜, 마지막 날짜 초기 설정
     initMonthStandard(startDay, endDay) {
         this.monthStandard = {
             startDay: startDay, 
@@ -65,6 +77,7 @@ const CalenderUtils = {
         };
     },
 
+    // 매 달의 시작날과 금일을 수정하여 반환
     filterMonth(monthList) {
         const filterMonth = monthList.map((dateChar) => {
             const date = dateChar.split('-');
@@ -84,12 +97,31 @@ const CalenderUtils = {
         return filterMonth;
     },
 
+    // 10보다 작은 수는 '0'을 붙여 반환
     tensCheck(number) {
         if(Number(number) < 10) {
             return `0${number}`;
         }
         return number;
-    }
+    },
+
+    // 캘린더 리스트 수정하여 반환
+    updateCalender(direction) {
+        this.updateStandard(direction);
+
+        let updateMonthList = this.getDatesMonth();
+        updateMonthList = this.filterMonth(updateMonthList);
+
+        return updateMonthList;
+    },
+
+    // 기준 날짜 수정
+    updateStandard(direction) {
+        const plusDay = direction === 'right' ? 35 : -35;
+
+        this.monthStandard.startDay.setDate(this.monthStandard.startDay.getDate() + plusDay);
+        this.monthStandard.endDay.setDate(this.monthStandard.endDay.getDate() + plusDay);
+    },
 }
 
 export default CalenderUtils;


### PR DESCRIPTION
Add
MainCalender.js
- clickBtn: 달력 좌우 버튼 클릭을 관리하는 state
- directionBtn: 좌우 버튼 중 어디를 클릭했는지 관리하는 state
- useEffect: 초기 오늘을 기준으로 달력 세팅, 버튼 클릭 시 좌우 판단하여 달력 세팅
- turnOverCalender: 좌우 버튼 클릭 시 state 변경

CalenderUtils.js
- 함수 별 주석 추가
- updateCalender(): 버튼 클릭시 호출되는 함수. 날짜 리스트 생성 및 반환
- updateStandard(): 버튼 방향에 따라 달력의 시작, 종료 날짜를 결정

Update
MainCalender.js
- calenderBody(): 날짜 리스트가 없을 경우를 대비하여 조건문 추가

CalenderUtils.js
- getDatesMonth(): 인자 삭제 &  setDate 시 기존의 날짜가 변경되는 사항 고려하여 마지막에 다시 변경된 만큼 수정

좌우 버튼 클릭 시 35일 +, -를 판단하여 날짜 리스트 변경 및 출력